### PR TITLE
Setting up Travis CI automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
-install: mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
+dist: xenial
+os:
+  - osx
+  - linux
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PLATFORM=macosx-x86_64   ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PLATFORM=linux-x86_64  ; fi
+install: mvn -B -V -pl shap4j -Djavacpp.platform=$PLATFORM -DskipTests -Dmaven.javadoc.skip=true install
 script:
-  - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 test
+  - mvn -B -pl shap4j -Djavacpp.platform=$PLATFORM test
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
-install:
-  - mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
+install: skip
 script:
+  - mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
   - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 clean compile test
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: java
 install:
   - mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
 script:
-  - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 test -B
+  - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 clean compile test
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install: mvn -B -V -pl shap4j -Djavacpp.platform=$PLATFORM -DskipTests -Dmaven.j
 script:
   - mvn -B -pl shap4j -Djavacpp.platform=$PLATFORM test
 jdk:
-  - openjdk8
+  - openjdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
-install: skip
+install: mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
 script:
-  - mvn -B -V -pl shap4j -Djavacpp.platform=linux-x86_64 -DskipTests -Dmaven.javadoc.skip=true install
-  - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 clean compile test
+  - mvn -B -pl shap4j -Djavacpp.platform=linux-x86_64 test
 jdk:
   - openjdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # shap4j
 
+![Build Status](https://api.travis-ci.org/xydrolase/shap4j.svg?branch=master)
+
 JVM interface for the [SHAP (SHapley Additive exPlanations) library](https://github.com/slundberg/shap) for tree 
 ensembles (`TreeExplainer`.), built using [`javacpp`](https://github.com/bytedeco/javacpp)
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <javacpp.moduleId>shap4j</javacpp.moduleId>
         <javacpp.version>1.5.3</javacpp.version>
         <javacpp.platform></javacpp.platform>
-        <javacpp.platform.nativeOutputPath>org/bytedeco/${project.artifactId}/${javacpp.platform}</javacpp.platform.nativeOutputPath>
+        <javacpp.platform.nativeOutputPath>${project.artifactId}/${javacpp.platform}</javacpp.platform.nativeOutputPath>
         <scala.version>2.12.11</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/shap4j/pom.xml
+++ b/shap4j/pom.xml
@@ -40,6 +40,10 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <argLine>-Djava.library.path=${project.build.directory}/native/${javacpp.platform.nativeOutputPath}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
# Overview
Setting up Travis CI automation to validate the builds across platforms.

# ToDos
 - [x] Unit tests automation on `linux-x86_64`
 - [x] Use `matrix` to validate builds on both `macosx` and `linux`