### PR TITLE
Prepare for Sonatype release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PLATFORM=macosx-x86_64   ; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PLATFORM=linux-x86_64  ; fi
-install: mvn -B -V -pl shap4j -Djavacpp.platform=$PLATFORM -DskipTests -Dmaven.javadoc.skip=true install
+install: mvn -B -V -pl shap4j -Dgpg.skip=true -Djavacpp.platform=$PLATFORM -DskipTests -Dmaven.javadoc.skip=true install
 script:
   - mvn -B -pl shap4j -Djavacpp.platform=$PLATFORM test
 jdk:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 JVM interface for the [SHAP (SHapley Additive exPlanations) library](https://github.com/slundberg/shap) for tree 
 ensembles (`TreeExplainer`.), built using [`javacpp`](https://github.com/bytedeco/javacpp)
 
-## Use cases
+#### Use cases
 `shap4j` enables lean SHAP integration in JVM projects, without dependencies on third party tree ensemble runtime 
 libraries, _e.g._ XGBoost and LightGBM.
 
@@ -14,26 +14,37 @@ To generate SHAP values for a specific tree ensemble model, the model must be pr
 can be generated from model dumps of XGBoost/LightGBM/CatBoost/sklearn using the Python library
 [`shap4j-data-converter`](https://github.com/xydrolase/shap4j-data-converter).
 
-## Example usage
+## Usage
+
+#### Maven
+```xml
+<dependency>
+  <groupId>io.github.xydrolase</groupId>
+  <artifactId>shap4j-platform</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+#### Example usage
 ```java
-    package examples;
+package examples;
 
-    import java.nio.file.Files;
-    import java.io.File;
-    import shap4j.TreeExplainer;
+import java.nio.file.Files;
+import java.io.File;
+import shap4j.TreeExplainer;
 
-    class ExampleApp {
-        public static void main(String[] args) throws Exception {
-            byte[] data = Files.readAllBytes(new File("boston.shap4j").toPath());
-            TreeExplainer explainer = new TreeExplainer(data);
-            double[] x = {
-                    6.320e-03, 1.800e+01, 2.310e+00, 0.000e+00, 5.380e-01, 6.575e+00,
-                    6.520e+01, 4.090e+00, 1.000e+00, 2.960e+02, 1.530e+01, 3.969e+02,
-                    4.980e+00
-            };
-            double[] shapValues = explainer.shapValues(x, false);
+class ExampleApp {
+    public static void main(String[] args) throws Exception {
+        byte[] data = Files.readAllBytes(new File("boston.shap4j").toPath());
+        TreeExplainer explainer = new TreeExplainer(data);
+        double[] x = {
+                6.320e-03, 1.800e+01, 2.310e+00, 0.000e+00, 5.380e-01, 6.575e+00,
+                6.520e+01, 4.090e+00, 1.000e+00, 2.960e+02, 1.530e+01, 3.969e+02,
+                4.980e+00
+        };
+        double[] shapValues = explainer.shapValues(x, false);
 
-            System.out.println("SHAP values: " + Arrays.toString(shapValues));
-        }
+        System.out.println("SHAP values: " + Arrays.toString(shapValues));
     }
+}
 ```

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -20,14 +20,6 @@
             <artifactId>${javacpp.moduleId}</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>${javacpp.moduleId}</artifactId>
-            <version>${project.version}</version>
-            <classifier>linux-x86</classifier>
-        </dependency>
-        -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>${javacpp.moduleId}</artifactId>
@@ -77,38 +69,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-module-infos</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>add-platform-module-info</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>add-module-info</goal>
-                        </goals>
-                        <configuration>
-                            <modules>
-                                <module>
-                                    <file>${project.build.directory}/${project.artifactId}.jar</file>
-                                    <moduleInfoSource>
-                                        module org.bytedeco.${javacpp.moduleId}.platform {
-                                        requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
-                                        requires org.bytedeco.${javacpp.moduleId}.macosx.x86_64;
-                                        }
-                                    </moduleInfoSource>
-                                </module>
-                            </modules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
     </build>
 

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.xydrolase</groupId>
+        <groupId>io.github.xydrolase</groupId>
         <artifactId>shap4j-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>SHAP4j</name>
+    <name>shap4j</name>
     <description>Java wrapper of the SHAP library (https://github.com/slundberg/shap)</description>
     <url>https://github.com/xydrolase/shap4j</url>
 
@@ -103,23 +103,6 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>
-                    <!--
-                    <execution>
-                        <id>default-jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>org/bytedeco/${javacpp.packageName}/**</include>
-                            </includes>
-                            <excludes>
-                                <exclude>org/bytedeco/${javacpp.packageName}/include/</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    -->
                     <execution>
                         <id>javacpp-${javacpp.platform}</id>
                         <phase>package</phase>
@@ -145,9 +128,89 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         </pluginManagement>
     </build>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,39 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.xydrolase</groupId>
+    <groupId>io.github.xydrolase</groupId>
     <artifactId>shap4j-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+    <name>SHAP4j</name>
+    <description>Java wrapper of the SHAP library (https://github.com/slundberg/shap)</description>
+    <url>https://github.com/xydrolase/shap4j</url>
+
+    <organization>
+        <name>io.github.xydrolase</name>
+        <url>https://github.com/xydrolase/shap4j</url>
+    </organization>
+
+    <scm>
+        <url>https://github.com/xydrolase/shap4j</url>
+        <connection>scm:git:git://github.com/xydrolase/shap4j.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:xydrolase/shap4j.git</developerConnection>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://github.com/xydrolase/shap4j/blob/master/LICENSE</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Xin Yin</name>
+            <email>xydrolase@gmail.com</email>
+        </developer>
+    </developers>
 
     <properties>
         <javacpp.moduleId>shap4j</javacpp.moduleId>
@@ -147,4 +176,6 @@
         </plugins>
         </pluginManagement>
     </build>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -141,38 +141,10 @@
                                 </manifestEntries>
                             </archive>
                             <classesDirectory>${project.build.directory}/native</classesDirectory>
-                            <!--
-                            <excludes>
-                                <exclude>org/bytedeco/${javacpp.packageName}/windows-*/*.exp</exclude>
-                                <exclude>org/bytedeco/${javacpp.packageName}/windows-*/*.lib</exclude>
-                                <exclude>org/bytedeco/${javacpp.packageName}/windows-*/*.obj</exclude>
-                            </excludes>
-                            -->
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
         </pluginManagement>
     </build>

--- a/shap4j/pom.xml
+++ b/shap4j/pom.xml
@@ -45,35 +45,18 @@
                     <argLine>-Djava.library.path=${project.build.directory}/native/${javacpp.platform.nativeOutputPath}</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
-
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/shap4j/pom.xml
+++ b/shap4j/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.xydrolase</groupId>
+        <groupId>io.github.xydrolase</groupId>
         <artifactId>shap4j-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../</relativePath>

--- a/shap4j/src/main/java/shap4j/TreeExplainer.java
+++ b/shap4j/src/main/java/shap4j/TreeExplainer.java
@@ -9,7 +9,7 @@ import shap4j.shap.TreeShap;
 /**
  * A SHAP explainer using Tree SHAP algorithms to explain the output of tree ensemble models.
  *
- * @see <a href="https://github.com/slundberg/shap/blob/master/shap/explainers/tree.py>Python interface for TreeExplainer</a>
+ * @see <a href="https://github.com/slundberg/shap/blob/master/shap/explainers/tree.py">Python interface for TreeExplainer</a>
  */
 public class TreeExplainer {
     private static final int TREE_PATH_DEPENDENT_FEATURE = 1;

--- a/shap4j/src/main/java/shap4j/TreeExplainer.java
+++ b/shap4j/src/main/java/shap4j/TreeExplainer.java
@@ -6,6 +6,11 @@ import shap4j.shap.ExplanationDataset;
 import shap4j.shap.TreeEnsemble;
 import shap4j.shap.TreeShap;
 
+/**
+ * A SHAP explainer using Tree SHAP algorithms to explain the output of tree ensemble models.
+ *
+ * @see <a href="https://github.com/slundberg/shap/blob/master/shap/explainers/tree.py>Python interface for TreeExplainer</a>
+ */
 public class TreeExplainer {
     private static final int TREE_PATH_DEPENDENT_FEATURE = 1;
     private static final int IDENTITY_TRANSFORM = 0;
@@ -16,11 +21,26 @@ public class TreeExplainer {
         this.treeEnsemble = ensemble;
     }
 
+    /**
+     * Create a instance of <code>TreeExplainer</code> from binary data: <code>rawData</code>.
+     * @see <a href="https://github.com/xydrolase/shap4j-data-converter/">shap4j-data-converter for creating the data</a>
+     * @param rawData The binary raw data representing a tree ensemble model, upon which a <code>TreeExplainer</code> is
+     *                based.
+     */
     public TreeExplainer(byte[] rawData) {
         this.treeEnsemble = TreeEnsemble.fromBytes(rawData);
     }
 
+
     // TODO: add support for TreeExplainer.data (a background dataset to use for integrating out features.)
+    /**
+     * Compute the SHAP values for a given 2-dimensional matrix: <code>matrix</code>.
+     * @param matrix The 2d matrix from which the SHAP values are computed. Each row in this matrix should correspond
+     *               to a feature vector.
+     * @param checkMissing Whether to check missing values in <code>matrix</code>. If set to false, all values in
+     *                     <code>matrix</code> are assumed to be non-missing (i.e. not <code>NaN</code>.)
+     * @return A 2d matrix containing the SHAP values, which should be of the same shape as the input <code>matrix</code>.
+     */
     public double[][] shapValues(double [][] matrix, boolean checkMissing) {
         assert matrix.length > 0;
 
@@ -52,6 +72,12 @@ public class TreeExplainer {
         return values;
     }
 
+    /**
+     * Compute SHAP values for a given feature vector: <code>vector</code>.
+     * @param vector A feature vector compatible with the tree ensemble model.
+     * @param checkMissing Whether to check missing values in the feature vector (<code>NaN</code>'s)
+     * @return An array containing SHAP values, which is of the same length of the input <code>vector</code>.
+     */
     public double[] shapValues(double [] vector, boolean checkMissing) {
         double[][] matrix = {vector};
 


### PR DESCRIPTION
# Overview
This PR prepares the project for Nexus Sonatype releases per the [requirements](https://central.sonatype.org/pages/requirements.html) of the Central repository:
 
 - Updated `pom.xml` to add license, `scm` and project description.
 - Added `maven-sources-plugin`, `maven-javadoc-plugin` and `maven-gpg-plugin`.
 - Added JavaDoc for the main `TreeExplainer` class.
 - Updated `README` for more example usage.