### PR TITLE
Added support for the Saabas algorithm for approximate SHAP values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,27 @@
 
 ![Build Status](https://api.travis-ci.org/xydrolase/shap4j.svg?branch=master)
 
-JVM interface for the [SHAP (SHapley Additive exPlanations) library](https://github.com/slundberg/shap) for tree 
-ensembles (`TreeExplainer`.), built using [`javacpp`](https://github.com/bytedeco/javacpp)
+Java interface for the [SHAP (SHapley Additive exPlanations) library](https://github.com/slundberg/shap) for tree 
+ensembles (`TreeExplainer`). Note that `shap4j` is not a pure Java port of SHAP. Rather, it utilizes
+[`JavaCPP`](https://github.com/bytedeco/javacpp) to provide a Java-Native Interface (JNI) on top of the
+[fast C++ implementation of `TreeExplainer`](https://github.com/slundberg/shap/blob/master/shap/tree_shap.h).
+In this sense, `shap4j` leverages the same underlying native code that powers the
+[Python version of `TreeExplainer`](https://github.com/slundberg/shap#tree-ensemble-example-with-treeexplainer-xgboostlightgbmcatboostscikit-learnpyspark-models),
+to ensure validity and efficiency.
+
+Current supported platforms:
+
+ - `macosx-x86_64`
+ - `linux-x86_64`
 
 #### Use cases
-`shap4j` enables lean SHAP integration in JVM projects, without dependencies on third party tree ensemble runtime 
-libraries, _e.g._ XGBoost and LightGBM.
+`shap4j` enables lean SHAP integration in JVM projects, _i.e._ a project can import `shap4j` as the sole dependency,
+without having to depend on heavier third-party tree ensemble libraries, 
+_e.g._ [`xgboost4j`](https://github.com/dmlc/xgboost/tree/master/jvm-packages).
 
 ## Data generation
-To generate SHAP values for a specific tree ensemble model, the model must be provided in a `.shap4j` data file, which
-can be generated from model dumps of XGBoost/LightGBM/CatBoost/sklearn using the Python library
+To generate SHAP values for a specific tree ensemble model, that model must be provided in a `.shap4j` data file, which
+can be generated from model dumps of XGBoost/LightGBM/CatBoost/sklearn using the companion Python library
 [`shap4j-data-converter`](https://github.com/xydrolase/shap4j-data-converter).
 
 ## Usage

--- a/shap4j/pom.xml
+++ b/shap4j/pom.xml
@@ -29,6 +29,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/shap4j/src/main/java/shap4j/TreeExplainer.java
+++ b/shap4j/src/main/java/shap4j/TreeExplainer.java
@@ -6,6 +6,11 @@ import shap4j.shap.ExplanationDataset;
 import shap4j.shap.TreeEnsemble;
 import shap4j.shap.TreeShap;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
 /**
  * A SHAP explainer using Tree SHAP algorithms to explain the output of tree ensemble models.
  *
@@ -31,34 +36,31 @@ public class TreeExplainer {
         this.treeEnsemble = TreeEnsemble.fromBytes(rawData);
     }
 
-
-    // TODO: add support for TreeExplainer.data (a background dataset to use for integrating out features.)
     /**
-     * Compute the SHAP values for a given 2-dimensional matrix: <code>matrix</code>.
-     * @param matrix The 2d matrix from which the SHAP values are computed. Each row in this matrix should correspond
-     *               to a feature vector.
-     * @param checkMissing Whether to check missing values in <code>matrix</code>. If set to false, all values in
-     *                     <code>matrix</code> are assumed to be non-missing (i.e. not <code>NaN</code>.)
-     * @return A 2d matrix containing the SHAP values, which should be of the same shape as the input <code>matrix</code>.
+     * Compute the SHAP values for a given <code>ExplanationDataset</code>.
+     *
+     * @param dataset An instance of <code>ExplanationDataset</code>.
+     * @param approximate Run the approximate Saabas algorithm which is fast but only considers a single feature
+     *                    ordering. See https://github.com/slundberg/shap/edit/master/shap/explainers/tree.py for
+     *                    more details.
+     * @return The SHAP values in a 2d array, which is of the same shape as <code>dataset.X()</code>.
      */
-    public double[][] shapValues(double [][] matrix, boolean checkMissing) {
-        assert matrix.length > 0;
+    public double[][] shapValues(ExplanationDataset dataset, boolean approximate) {
+        int nRows = dataset.getNumRows();
+        // the SHAP values, or phi, has an extra column
+        int nCols = dataset.getNumCols() + 1;
 
-        int nRows = matrix.length;
-        int nCols = matrix[0].length + 1;
-
-        if (treeEnsemble.num_outputs() != 1) {
-            throw new IllegalArgumentException("Currently only supporting models with num_outputs == 1");
-        }
-
-        ExplanationDataset dataset = ExplanationDataset.fromMatrix(matrix, checkMissing);
         DoublePointer phi = new DoublePointer(nRows * nCols);
         // set initial values for the SHAP values to zero, as tree_shap_recursive adds to these values.
         BytePointer.memset(phi, 0, nRows  * nCols * 8);
 
-        TreeShap.dense_tree_shap(treeEnsemble, dataset, phi,
-                TREE_PATH_DEPENDENT_FEATURE, IDENTITY_TRANSFORM, false
-        );
+        if (approximate) {
+            TreeShap.dense_tree_saabas(phi, treeEnsemble, dataset);
+        } else {
+            TreeShap.dense_tree_shap(treeEnsemble, dataset, phi,
+                    TREE_PATH_DEPENDENT_FEATURE, IDENTITY_TRANSFORM, false
+            );
+        }
 
         double[][] values = new double[nRows][nCols - 1];
         int offset = 0;
@@ -73,7 +75,66 @@ public class TreeExplainer {
     }
 
     /**
+     * Compute the SHAP values for a given <code>ExplanationDataset</code> using the exact algorithm.
+     * @param dataset An instance of <code>ExplanationDataset</code>.
+     * @return The SHAP values in a 2d array, which is of the same shape as <code>dataset.X()</code>.
+     */
+    public double[][] shapValues(ExplanationDataset dataset) {
+        return shapValues(dataset, false);
+    }
+
+    /**
+     * Compute the SHAP values for a given 2-dimensional matrix: <code>matrix</code>.
+     * @param matrix The 2d matrix from which the SHAP values are computed. Each row in this matrix should correspond
+     *               to a feature vector.
+     * @param approximate Run the approximate Saabas algorithm which is fast but only considers a single feature
+     *                    ordering. See https://github.com/slundberg/shap/edit/master/shap/explainers/tree.py for
+     *                    more details.
+     * @param checkMissing Whether to check missing values in <code>matrix</code>. If set to false, all values in
+     *                     <code>matrix</code> are assumed to be non-missing (i.e. not <code>NaN</code>.)
+     * @return A 2d matrix containing the SHAP values, which should be of the same shape as the input <code>matrix</code>.
+     */
+    public double[][] shapValues(double [][] matrix, boolean approximate, boolean checkMissing) {
+        assert matrix.length > 0;
+
+        if (treeEnsemble.num_outputs() != 1) {
+            throw new IllegalArgumentException("Currently only supporting models with num_outputs == 1");
+        }
+
+        ExplanationDataset dataset = ExplanationDataset.fromMatrix(matrix, checkMissing);
+
+        return shapValues(dataset, approximate);
+    }
+
+    /**
+     * Compute the SHAP values for a given 2-dimensional matrix: <code>matrix</code>, using the exact algorithm.
+     * @param matrix The 2d matrix from which the SHAP values are computed. Each row in this matrix should correspond
+     *               to a feature vector.
+     * @param checkMissing Whether to check missing values in <code>matrix</code>. If set to false, all values in
+     *                     <code>matrix</code> are assumed to be non-missing (i.e. not <code>NaN</code>.)
+     * @return A 2d matrix containing the SHAP values, which should be of the same shape as the input <code>matrix</code>.
+     */
+    public double[][] shapValues(double [][] matrix, boolean checkMissing) {
+        return shapValues(matrix, false, checkMissing);
+    }
+
+    /**
      * Compute SHAP values for a given feature vector: <code>vector</code>.
+     * @param vector A feature vector compatible with the tree ensemble model.
+     * @param approximate Run the approximate Saabas algorithm which is fast but only considers a single feature
+     *                    ordering. See https://github.com/slundberg/shap/edit/master/shap/explainers/tree.py for
+     *                    more details.
+     * @param checkMissing Whether to check missing values in the feature vector (<code>NaN</code>'s)
+     * @return An array containing SHAP values, which is of the same length of the input <code>vector</code>.
+     */
+    public double[] shapValues(double [] vector, boolean approximate, boolean checkMissing) {
+        double[][] matrix = {vector};
+
+        return shapValues(matrix, approximate, checkMissing)[0];
+    }
+
+    /**
+     * Compute SHAP values for a given feature vector: <code>vector</code>, using the exact algorithm.
      * @param vector A feature vector compatible with the tree ensemble model.
      * @param checkMissing Whether to check missing values in the feature vector (<code>NaN</code>'s)
      * @return An array containing SHAP values, which is of the same length of the input <code>vector</code>.
@@ -81,6 +142,39 @@ public class TreeExplainer {
     public double[] shapValues(double [] vector, boolean checkMissing) {
         double[][] matrix = {vector};
 
-        return shapValues(matrix, checkMissing)[0];
+        return shapValues(matrix, false, checkMissing)[0];
+    }
+
+    /**
+     * Create a <code>TreeExplainer</code> from a resource file of the <code>.shap4j</code> format.
+     * @param resource The path to the resource file, e.g. <code>"/boston.shap4j"</code> if the file is located under
+     *                 <code>src/java/main/resources</code>.
+     * @return An <code>TreeExplainer</code> instance corresponding to the tree model contained by the resource file.
+     * @throws IOException
+     * @see <a href="https://github.com/xydrolase/shap4j-data-converter>shap4j-data-converter to create the .shap4j file</a>
+     */
+    public static TreeExplainer fromResource(String resource) throws IOException {
+        try(InputStream is = TreeExplainer.class.getResourceAsStream(resource)) {
+            byte[] data = new byte[is.available()];
+            is.read(data);
+
+            return new TreeExplainer(data);
+        }
+        catch (NullPointerException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Create a <code>TreeExplainer</code> from a local file of the <code>.shap4j</code> format.
+     * @param filePath The file path to the <code>.shap4j</code> file.
+     * @return An <code>TreeExplainer</code> instance corresponding to the tree model contained by the local file.
+     * @throws IOException
+     * @see <a href="https://github.com/xydrolase/shap4j-data-converter>shap4j-data-converter to create the .shap4j file</a>
+     */
+    public static TreeExplainer fromFile(String filePath) throws IOException {
+        byte[] data = Files.readAllBytes(new File(filePath).toPath());
+
+        return new TreeExplainer(data);
     }
 }

--- a/shap4j/src/main/java/shap4j/shap/ExplanationDataset.java
+++ b/shap4j/src/main/java/shap4j/shap/ExplanationDataset.java
@@ -11,6 +11,9 @@ public class ExplanationDataset extends Pointer {
         Loader.load();
     }
 
+    private int numRows;
+    private int numCols;
+
     private ExplanationDataset() {
         allocate();
     }
@@ -22,6 +25,9 @@ public class ExplanationDataset extends Pointer {
     private ExplanationDataset(DoublePointer X, BoolPointer X_missing, DoublePointer y, DoublePointer R,
                                BoolPointer R_missing, int num_X, int M, int num_R) {
         scope = new PointerScope();
+
+        this.numRows = num_X;
+        this.numCols = M;
 
         // attach all non-null pointers to a local scope, so that when ExplanationDataset is closed, all attached
         // pointers are closed/released accordingly as well.
@@ -77,5 +83,13 @@ public class ExplanationDataset extends Pointer {
 
         // reset position for X
         return new ExplanationDataset(XPtr.position(0L), XmissingPtr, null, null, null, num_X, M, 0);
+    }
+
+    public int getNumRows() {
+        return numRows;
+    }
+
+    public int getNumCols() {
+        return numCols;
     }
 }

--- a/shap4j/src/main/java/shap4j/shap/TreeShap.java
+++ b/shap4j/src/main/java/shap4j/shap/TreeShap.java
@@ -16,4 +16,8 @@ public class TreeShap {
                                               DoublePointer out_contribs,
                                               @Const int feature_dependence,
                                               int model_transform, boolean interactions);
+
+    public static native void dense_tree_saabas(DoublePointer out_contribs,
+                                                @Const @ByRef TreeEnsemble trees,
+                                                @Const @ByRef ExplanationDataset data);
 }


### PR DESCRIPTION
# Motivation
Adding support for the Saabas algorithm for computing approximate SHAP values. This algorithm is implemented as the `dense_tree_saabas` function in the C++ implementation. 

# Solution details
Added a new boolean parameter, `approximate`, to the `TreeExplainer.shapValues()` methods, which mirrors the Python interface `TreeExplainer.shap_values()`:
```python
def shap_values(self, X, y=None, tree_limit=None, approximate=False, check_additivity=True):
```

# Results
Added new unit tests to verify the output of the approximate SHAP values. The expected values are generated using the SHAP Python package.
