### PR TITLE
Fixed a potential data corruption bug in TreeExplainer.fromResource.

### DIFF
--- a/shap4j/src/main/java/shap4j/TreeExplainer.java
+++ b/shap4j/src/main/java/shap4j/TreeExplainer.java
@@ -155,8 +155,20 @@ public class TreeExplainer {
      */
     public static TreeExplainer fromResource(String resource) throws IOException {
         try(InputStream is = TreeExplainer.class.getResourceAsStream(resource)) {
-            byte[] data = new byte[is.available()];
-            is.read(data);
+            int bytesRemaining = is.available();
+            int readOffset = 0;
+            byte[] data = new byte[bytesRemaining];
+
+            while (bytesRemaining > 0) {
+                int bytesRead = is.read(data, readOffset, bytesRemaining);
+                if (bytesRead == -1) {
+                    // InputStream.read() returns -1 if it reaches the end of the stream.
+                    bytesRemaining = 0;
+                } else {
+                    bytesRemaining -= bytesRead;
+                    readOffset += bytesRead;
+                }
+            }
 
             return new TreeExplainer(data);
         }


### PR DESCRIPTION
# Overview
This PR attempts to fix a bug which may lead to incomplete data loading from a resource file. In particular, the old Java code

```java
            byte[] data = new byte[is.available()];
            is.read(data);
```
does not guarantee that we read every byte from the input stream. If the data file is only partially loaded into the byte array, it will result in data corruption, and consequently either invalid SHAP values, or more severe runtime errors.

The bugfix included in this PR should ensure that we exhaustively read all bytes from a given resource file.