### PR TITLE
Adding support for macosx-arm64.

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -31,6 +31,12 @@
             <version>${project.version}</version>
             <classifier>macosx-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${javacpp.moduleId}</artifactId>
+            <version>${project.version}</version>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <javacpp.moduleId>shap4j</javacpp.moduleId>
-        <javacpp.version>1.5.3</javacpp.version>
+        <javacpp.version>1.5.7</javacpp.version>
         <javacpp.platform />
         <javacpp.platform.nativeOutputPath>${project.artifactId}/${javacpp.platform}</javacpp.platform.nativeOutputPath>
         <scala.version>2.12.11</scala.version>


### PR DESCRIPTION
# Motivation
The existing release for `shap4j` does not support Mac M1 devices, which makes running & debugging JVM applications using shap4j locally difficult.

# Solution Details
Adding `macosx-arm64` as a new platform for cross-building. The next release (0.0.3) will contain native libraries built for `macosx-arm64`.